### PR TITLE
Instance Filter Fix

### DIFF
--- a/Scoop/Models/FirebaseListener.swift
+++ b/Scoop/Models/FirebaseListener.swift
@@ -55,8 +55,8 @@ import FirebaseFirestore
                     withId: document.documentID
                 )
                 
-                
-                if scoop.instance.isEmpty || scoop.instance != boop.instance {
+                // ignore results if the instance filter is set and it doesn't match
+                if !scoop.instance.isEmpty && boop.instance != scoop.instance {
                     return
                 }
                 boops.insert(boop, at: 0)

--- a/Scoop/Views/ContentView.swift
+++ b/Scoop/Views/ContentView.swift
@@ -46,10 +46,7 @@ struct ContentView: View {
             }
         } detail: {
             if let activeScoop {
-                NavigationStack {
-                    ScoopView(scoop: activeScoop)
-                }
-                .navigationTitle(activeScoop.title)
+                ScoopView(scoop: activeScoop)
             }
         }
     }

--- a/Scoop/Views/List/ScoopView.swift
+++ b/Scoop/Views/List/ScoopView.swift
@@ -31,6 +31,7 @@ struct ScoopView: View {
                 }
             }
         }
+        .navigationTitle(scoop.title)
         .onChange(of: isEditorPresented) {
             if !isEditorPresented {
                 beginListening()


### PR DESCRIPTION
Faulty logic in the listener made it so that you would have to specify the `instance` value in order to see any results. This PR makes it so that setting the `instance` value on a Scoop is optional, as expected