### PR TITLE
24-hour Session Chart and Index Creation

### DIFF
--- a/Scoop/Assets.xcassets/Chart/Contents.json
+++ b/Scoop/Assets.xcassets/Chart/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Scoop/Assets.xcassets/Chart/GridLine.colorset/Contents.json
+++ b/Scoop/Assets.xcassets/Chart/GridLine.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.925",
+          "green" : "0.740",
+          "red" : "0.594"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "149",
+          "green" : "160",
+          "red" : "186"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Scoop/Assets.xcassets/Chart/Highlight.colorset/Contents.json
+++ b/Scoop/Assets.xcassets/Chart/Highlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.577",
+          "green" : "0.761",
+          "red" : "0.315"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.256",
+          "green" : "0.792",
+          "red" : "0.792"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Scoop/Models/BoopSession.swift
+++ b/Scoop/Models/BoopSession.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct BoopSession: Identifiable {
+    var id: String
+    var startTime: Date
+    var endTime: Date
+    
+    var duration: TimeInterval {
+        endTime.timeIntervalSince(startTime)
+    }
+    
+    init (id: String, startTime: Date, endTime: Date) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+    
+    init(from boop: BoopItem) throws {
+        guard let milliseconds = boop.value as? Int else {
+            throw NSError(domain: "BoopSession must be initialized with a SessionStop event with Int value", code: 1, userInfo: nil)
+        }
+        let negative_duration: Double = TimeInterval(milliseconds) / -1000
+        id = boop.id
+        startTime = boop.timestamp.addingTimeInterval(negative_duration)
+        endTime = boop.timestamp
+    }
+    
+    static func generateRandomTimeline(count: Int) -> [BoopSession] {
+        var sessions: [BoopSession] = []
+        var latestTime: Date = .now
+        for _ in 0..<count {
+            let randomOffset = Double.random(in: 0...3600) // Random offset between 0 and 1 hour
+            let endTime = latestTime.addingTimeInterval(-randomOffset)
+            let randomDuration = Double.random(in: 10...1200) // Random duration between 10 seconds and 20 minutes
+            let startTime = endTime.addingTimeInterval(-randomDuration)
+            let session = BoopSession(id: UUID().uuidString, startTime: startTime, endTime: endTime)
+            sessions.append(session)
+            latestTime = startTime
+        }
+        return sessions
+    }
+}

--- a/Scoop/Models/Debouncer.swift
+++ b/Scoop/Models/Debouncer.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Dispatch
+
+class Debouncer {
+    private var workItem: DispatchWorkItem?
+    private let queue: DispatchQueue
+    
+    init(queue: DispatchQueue = DispatchQueue.main) {
+        self.queue = queue
+    }
+    
+    func delay(for delay: TimeInterval, _ block: @escaping () -> Void) {
+        workItem?.cancel()
+        workItem = DispatchWorkItem(block: block)
+        queue.asyncAfter(deadline: .now() + delay, execute: workItem!)
+    }
+}

--- a/Scoop/Models/FirebaseListener.swift
+++ b/Scoop/Models/FirebaseListener.swift
@@ -17,8 +17,6 @@ import FirebaseFirestore
     }
     
     func listen() {
-        removeAll()
-        
         let collectionRef = Firestore.firestore().collection(
             scoop.collectionVariant
         )
@@ -138,6 +136,7 @@ import FirebaseFirestore
     func removeAll() {
         self.listener?.remove()
         self.boops.removeAll()
+        self.sessions.removeAll()
     }
     
     deinit {

--- a/Scoop/Models/FirebaseListener.swift
+++ b/Scoop/Models/FirebaseListener.swift
@@ -28,8 +28,8 @@ import FirebaseFirestore
                 isGreaterThanOrEqualTo: FirebaseFirestore.Timestamp(date: Date())
             )
         
-        if !scoop.instance.isEmpty {
-            query = query.whereField("instance", isEqualTo: scoop.instance)
+        if !scoop.instanceFilter.isEmpty {
+            query = query.whereField("instance", isEqualTo: scoop.instanceFilter)
         }
         
         query = query.order(by: "timestamp", descending: true)
@@ -83,8 +83,8 @@ import FirebaseFirestore
                 isEqualTo: BoopEvent.sessionStop.rawValue
             )
         
-        if !scoop.instance.isEmpty {
-            query = query.whereField("instance", isEqualTo: scoop.instance)
+        if !scoop.instanceFilter.isEmpty {
+            query = query.whereField("instance", isEqualTo: scoop.instanceFilter)
         }
         
         query = query.order(by: "timestamp", descending: true)

--- a/Scoop/Models/FirebaseListener.swift
+++ b/Scoop/Models/FirebaseListener.swift
@@ -7,6 +7,7 @@ import FirebaseFirestore
 @Observable class FirebaseListener {
     var scoop: ScoopModel
     var boops: [BoopItem] = []
+    var sessions: [BoopSession] = []
 
     private var listener: ListenerRegistration?
     
@@ -60,6 +61,59 @@ import FirebaseFirestore
                     return
                 }
                 boops.insert(boop, at: 0)
+                
+                if boop.eventCategory == .sessionStop,
+                   let session = try? BoopSession(from: boop) {
+                    sessions.append(session)
+                }
+            }
+        }
+    }
+    
+    func getSessions() {
+        let collectionRef = Firestore.firestore().collection(
+            scoop.collectionVariant
+        )
+        let query = collectionRef
+            .whereField(
+                "timestamp",
+                isGreaterThanOrEqualTo: FirebaseFirestore.Timestamp(date: 24.hoursAgo)
+            )
+            .whereField(
+                "event",
+                isEqualTo: BoopEvent.sessionStop.rawValue
+            )
+        
+        query.getDocuments { (querySnapshot: QuerySnapshot?, error: Error?) in
+            self.receiveSessionsSnapshot(querySnapshot: querySnapshot, error: error)
+        }
+    }
+    
+    private func receiveSessionsSnapshot(querySnapshot: QuerySnapshot?, error: Error?) {
+        if let error = error {
+            print("receiveSnapshot: error \(error.localizedDescription)")
+            return
+        }
+        
+        guard let snapshot = querySnapshot else {
+            print("receiveSnapshot: no snapshot")
+            return
+        }
+        
+        snapshot.documentChanges.forEach { diff in
+            if diff.type == .added {
+                let document = diff.document
+                let boop = BoopItem(from: document, withId: document.documentID)
+                
+                // ignore results if the instance filter is set and it doesn't match
+                if !scoop.instance.isEmpty && boop.instance != scoop.instance {
+                    return
+                }
+                
+                if boop.eventCategory == .sessionStop,
+                   let session = try? BoopSession(from: boop) {
+                    sessions.append(session)
+                }
             }
         }
     }

--- a/Scoop/Models/ScoopModel.swift
+++ b/Scoop/Models/ScoopModel.swift
@@ -3,7 +3,7 @@ import SwiftData
 @Model final class ScoopModel {
     var nickname: String = ""
     var collection: String
-    var instance: String = ""
+    var instanceFilter: String = ""
     var isDevelopment: Bool = false
     
     var title: String {
@@ -12,10 +12,10 @@ import SwiftData
         }
         
         var _title = collection
-        if instance.isEmpty || instance == "default" {
+        if instanceFilter.isEmpty || instanceFilter == "default" {
             return _title
         }
-        _title += " (\(instance))"
+        _title += " (\(instanceFilter))"
         return _title
     }
     

--- a/Scoop/Views/Common/SessionChart.swift
+++ b/Scoop/Views/Common/SessionChart.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+import Charts
+
+extension Int {
+    /// gets Date by subtracting `n` hours from current time
+    var hoursAgo: Date {
+        return Calendar.current.date(byAdding: .hour, value: self * -1, to: .now) ?? .now.addingTimeInterval(self.hours * -1)
+    }
+    
+    var hours: TimeInterval {
+        Double(self) * 3600
+    }
+}
+
+/// Displays the last 24 hours of session activity
+struct SessionChart: View {
+    var data: [BoopSession] = []
+    
+    @State var starting: Date = 24.hoursAgo
+    @State var ending: Date = 0.hoursAgo
+    @State var minuteOffset: Int = 0
+    
+    @State var zoomLevel: TimeInterval = 8.hours
+    @State var scrollX: Date = 0.hoursAgo
+    
+    let hourLine = StrokeStyle(lineWidth: 1.0, dash: [2.0, 2.0])
+    let quarterLine = StrokeStyle(lineWidth: 1.0, dash: [2.0, 14.0])
+    
+    let dataDebounce: Debouncer = .init()
+    let zoomDebounce: Debouncer = .init()
+    
+    func setZoom(to level: TimeInterval) {
+        if level == zoomLevel { return }
+        
+        withAnimation(.easeInOut) {
+            zoomLevel = level
+        } completion: {
+            zoomDebounce.delay(for: 0.25) {
+                scrollX = 0.hoursAgo
+            }
+        }
+    }
+    
+    func resetTimeline() {
+        withAnimation {
+            starting = 24.hoursAgo
+            ending = 0.hoursAgo
+        }
+    }
+    
+    var body: some View {
+            VStack(spacing: 0) {
+                ZStack {
+                    Chart {
+                        if let scale = data.first {
+                            RectangleMark(
+                                xStart: .value("Start Time", scale.startTime),
+                                xEnd: .value("End Time", scale.startTime),
+                                yStart: .value("row", 0.0),
+                                yEnd: .value("row", 1.0)
+                            )
+                        }
+                        ForEach(data) { session in
+                            if session.duration > 1 {
+                                RectangleMark(
+                                    xStart: .value("Start Time", session.startTime),
+                                    xEnd: .value("End Time", session.endTime),
+                                    yStart: .value("row", 0.3),
+                                    yEnd: .value("row", 1.0)
+                                )
+                                .foregroundStyle(LinearGradient(colors: [.BoopEvent.sessionStart, .BoopEvent.sessionStart, .BoopEvent.sessionStop], startPoint: .leading, endPoint: .trailing))
+                            }
+                        }
+                    }
+                    .frame(height: 100)
+                    .chartXScale(domain: [starting, ending])
+                    .chartXAxis {
+                        AxisMarks(preset: .inset, values: .stride(by: .hour, roundLowerBound: true)) { value in
+                            let hourMark: Date.FormatStyle = .dateTime.hour(.conversationalDefaultDigits(amPM: .abbreviated))
+                            let dayMark: Date.FormatStyle = .dateTime.weekday(.wide)
+                            
+                            let dayLabel = AxisValueLabel(format: dayMark, collisionResolution: .disabled)
+                                .font(.caption.bold())
+                                .offset(y: 5)
+                            let hourLabel = AxisValueLabel(format: hourMark, collisionResolution: .disabled)
+                                .font(.caption2)
+                                .offset(y: -8)
+                            let gridLine = AxisGridLine(stroke: hourLine)
+                                .foregroundStyle(Color.Chart.gridLine)
+                            
+                            switch zoomLevel {
+                                case 24.hours:
+                                    if value.index % 16 == 0 {
+                                        dayLabel
+                                        hourLabel
+                                    }
+                                    if value.index % 8 == 0 {
+                                        gridLine
+                                    }
+                                case 8.hours:
+                                    if value.index % 8 == 0 {
+                                        dayLabel
+                                    }
+                                    if value.index % 2 == 0 {
+                                        gridLine
+                                        hourLabel
+                                    }
+                                case 4.hours:
+                                    if value.index % 4 == 0 {
+                                        dayLabel
+                                    }
+                                    hourLabel
+                                    gridLine
+                                default:
+                                    gridLine
+                                    dayLabel
+                                    hourLabel
+                            }
+                        }
+                        if zoomLevel < 4.hours {
+                            AxisMarks(preset: .inset, values: .stride(by: .minute, roundLowerBound: true)) { value in
+                                let minute = value.index + minuteOffset
+                                if minute % 15 == 0 && minute % 60 != 0 {
+                                    AxisGridLine(centered: true, stroke: quarterLine)
+                                        .foregroundStyle(Color.Chart.gridLine)
+                                }
+                            }
+                        }
+                    }
+                    .chartYAxis() {
+                        AxisMarks(preset: .inset, values: [0.3]) { value in
+                            AxisGridLine(centered: false, stroke: StrokeStyle(lineWidth: 1.0))
+                                .foregroundStyle(Color.Chart.gridLine)
+                        }
+                    }
+                    .chartScrollableAxes(.horizontal)
+                    .chartXVisibleDomain(length: zoomLevel)
+                    .chartScrollPosition(x: $scrollX)
+                    
+                    HStack {
+                        Spacer()
+                        Text("\(data.count)")
+                            .font(.title.weight(.black))
+                            .foregroundStyle(Color.Chart.highlight)
+                            .padding(.horizontal, 10)
+                    }
+                }
+                
+                HStack(spacing: 20) {
+                    Button("24 hr", action: { setZoom(to: 24.hours) })
+                        .disabled(zoomLevel == 24.hours)
+                    Button("8 hr", action: { setZoom(to: 8.hours) })
+                        .disabled(zoomLevel == 8.hours)
+                    Button("4 hr", action: { setZoom(to: 4.hours) })
+                        .disabled(zoomLevel == 4.hours)
+                    Button("1 hr", action: { setZoom(to: 1.hours) })
+                        .disabled(zoomLevel == 1.hours)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.capsule)
+                .font(.caption2.bold())
+                .padding(10)
+            }
+            .onChange(of: data.count, initial: true) {
+                dataDebounce.delay(for: 1) {
+                    resetTimeline()
+                }
+            }
+            .onChange(of: starting, initial: true) {
+                minuteOffset = Calendar.current.component(.minute, from: starting)
+            }
+        }
+}
+
+#Preview {
+    let sessions = BoopSession.generateRandomTimeline(count: 20)
+    SessionChart(data: sessions)
+}

--- a/Scoop/Views/Editor/ScoopEditorView.swift
+++ b/Scoop/Views/Editor/ScoopEditorView.swift
@@ -19,13 +19,13 @@ struct ScoopEditorView: View {
             // Edit
             scoop.nickname = nickName
             scoop.collection = collectionName
-            scoop.instance = instanceName
+            scoop.instanceFilter = instanceName
             scoop.isDevelopment = isDevelopment
         } else {
             // Add
             let newScoop = ScoopModel(collection: collectionName)
             newScoop.nickname = nickName
-            newScoop.instance = instanceName
+            newScoop.instanceFilter = instanceName
             newScoop.isDevelopment = isDevelopment
             modelContext.insert(newScoop)
         }
@@ -78,7 +78,7 @@ struct ScoopEditorView: View {
             if let scoop {
                 nickName = scoop.nickname
                 collectionName = scoop.collection
-                instanceName = scoop.instance
+                instanceName = scoop.instanceFilter
                 isDevelopment = scoop.isDevelopment
             }
         }

--- a/Scoop/Views/List/ScoopView.swift
+++ b/Scoop/Views/List/ScoopView.swift
@@ -11,12 +11,44 @@ struct ScoopView: View {
         listener.listen()
     }
     
+    private func handleIndexCreation() {
+        guard let url = listener.indexUrls.keys.first else { return }
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url)
+            listener.indexUrls.removeValue(forKey: url)
+        }
+    }
+    
     var body: some View {
         NavigationStack {
-            VStack {
-                SessionChart(data: listener.sessions)
-                BoopListView(boops: listener.boops)
-                    .padding()
+            ZStack {
+                VStack {
+                    SessionChart(data: listener.sessions)
+                    BoopListView(boops: listener.boops)
+                        .padding()
+                }
+                if listener.indexUrls.count > 0 {
+                    VStack {
+                        Spacer()
+                        Button(action: handleIndexCreation) {
+                            Label {
+                                VStack(alignment: .leading) {
+                                    Text("\(listener.indexUrls.count) \(listener.indexUrls.count == 1 ? "Index" : "Indices") Required")
+                                        .foregroundColor(.primary)
+                                    Text("Tap to create index in Cloud Firestore console.")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            } icon: {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.yellow)
+                            }
+                            .padding(10)
+                        }
+                        .buttonStyle(.bordered)
+                        .buttonBorderShape(.capsule)
+                    }
+                }
             }
             .sheet(isPresented: $isEditorPresented) {
                 ScoopEditorView(scoop: scoop)

--- a/Scoop/Views/List/ScoopView.swift
+++ b/Scoop/Views/List/ScoopView.swift
@@ -7,13 +7,17 @@ struct ScoopView: View {
     
     private func beginListening() {
         listener = .init(for: scoop)
+        listener.getSessions()
         listener.listen()
     }
     
     var body: some View {
         NavigationStack {
-            BoopListView(boops: listener.boops)
-            .padding()
+            VStack {
+                SessionChart(data: listener.sessions)
+                BoopListView(boops: listener.boops)
+                    .padding()
+            }
             .sheet(isPresented: $isEditorPresented) {
                 ScoopEditorView(scoop: scoop)
             }

--- a/Scoop/Views/List/ScoopView.swift
+++ b/Scoop/Views/List/ScoopView.swift
@@ -70,11 +70,15 @@ struct ScoopView: View {
         .navigationTitle(scoop.title)
         .onChange(of: isEditorPresented) {
             if !isEditorPresented {
+                listener.removeAll()
                 beginListening()
             }
         }
         .onAppear {
             beginListening()
+        }
+        .onDisappear {
+            listener.removeAll()
         }
     }
 }


### PR DESCRIPTION
**features and fixes**
- improves the efficiency of Firestore queries but requires indices
- offers index prompt that opens auto-generated Firestore URL
- adds a 24-hour session chart to views